### PR TITLE
Improve wording around standard

### DIFF
--- a/docs/1_Start_Here/1_1_Introduction.md
+++ b/docs/1_Start_Here/1_1_Introduction.md
@@ -1,15 +1,15 @@
 ---
 title: Introduction
-description: Introduction to the Open3P open data standard for the plastic value chain.
+description: Introduction to the Open 3P open data standard for the packaging value chain.
 ---
 
 # Introduction
 
-## What is the Open3P?
+## What is the Open 3P?
 
-Open3P is an open data standard for plastic packaging. It has been developed as part of the Plastics Packaging Portals (PPP) Project, an Innovate UK supported project under the Smart Sustainable Plastic Packaging (SSPP) Fund. The project is led by OPRL alongside project partners Open Data Manchester, Dsposal, RECOUP, and Ecosurety.
+Open 3P is an open data standard for packaging. It has been developed as part of the Plastics Packaging Portals (PPP) Project, an Innovate UK supported project under the Smart Sustainable Plastic Packaging (SSPP) Fund. The project is led by OPRL alongside project partners Open Data Manchester, Dsposal, RECOUP, and Ecosurety.
 
-The project brings together stakeholders from the entire plastic packaging ecosystem to explore how we might create the foundations for systemic change 
+The project brings together stakeholders from the entire packaging ecosystem to explore how we might create the foundations for systemic change 
 in the packaging value chain. We have had more than 80 individuals from over 40 organisations take part in our workshops, interviews and research and we are incredibly grateful to them for sharing their time, expertise and support. 
 
 PPP has 5 main aims which will be delivered by 30th November 2022:
@@ -17,11 +17,11 @@ PPP has 5 main aims which will be delivered by 30th November 2022:
 1. Extend the Open3R Household Waste Recycling Centre (HWRCs) [data standard](https://opendatamanchester.github.io/Open3R/){target=_blank}
 2. Develop a prototype portal to capture data on geographically located recycling services such as HWRCs, bring banks, instore take back schemes
 to support a comprehensive open database of this information
-3. Develop an open standard for plastic packaging data (Open3P)
+3. Develop an open standard for plastic packaging data (Open 3P)
 4. Develop a prototype portal to capture packaging attribute data to enable it to be shared along the plastic packaging value chain and reported on
 5. Determine a sustainable business model and governance structure
 
-Although this funding and this phase of the project is focussed on plastic packaging, which is what Open3P covers currently, there is a commitment and desire to extend it to cover all types of packaging.
+Although this funding and this phase of the project is focussed on plastic packaging, which is what Open 3P covers currently, there is a commitment and desire to extend it to cover all types of packaging.
 
 By improving the data quality, granularity and availability of both packaging data and recycling services data and by enabling these datasets to be linked we believe we can support more sustainable packaging choices. By giving stakeholders visibility of the different parts of the chain we can help designers and manufacturers consider the end-of-life implications of their choices and we can help them determine the difference between a material being technically  recyclable and the practicality of it being recycled. Providing recyclers and reprocessors with detailed data about material types and recycling disruptors we can enable more materials to be kept at a higher value for longer. Improving these datasets also helps deliver better information into the hands of consumers to support them to recycle more. Better data on market trends in packaging can also provide more certainty and unlock investment and innovation so that we can increase our recycling infrastructure and ensure more of our waste packaging ends up recycled.
 

--- a/docs/1_Start_Here/1_2_Key_Concepts.md
+++ b/docs/1_Start_Here/1_2_Key_Concepts.md
@@ -1,6 +1,6 @@
 ---
 title: Key Concepts
-description: The key concepts to understanding the open data standard for the plastic value chain.
+description: The key concepts to understanding the open data standard for the packaging value chain.
 ---
 
 # Key Concepts

--- a/docs/1_Start_Here/1_3_Data_Flow.md
+++ b/docs/1_Start_Here/1_3_Data_Flow.md
@@ -1,6 +1,6 @@
 ---
 title: Data Flow
-description: The intented flow of data through the plastic value chain using Open3P.
+description: The intented flow of data through the packaging value chain using Open 3P.
 ---
 
 # Data Flow

--- a/docs/1_Start_Here/1_4_Data_Schema.md
+++ b/docs/1_Start_Here/1_4_Data_Schema.md
@@ -1,6 +1,6 @@
 ---
 title: Data Schema
-description: The current data schema of the Open3P open data standard for the plastic value chain.
+description: The current data schema of the Open 3P open data standard for the packaging value chain.
 ---
 
 # Data Schema

--- a/docs/4_Identifiers/4_1_Identifiers.md
+++ b/docs/4_Identifiers/4_1_Identifiers.md
@@ -4,9 +4,9 @@ title: Identifiers
 
 # Identifiers
 
-Identifiers are the way that humans and machines can know that a particular thing is definitely that thing. In the context of Open3P, there are different ways of talking about the various things involved. A packaging manufacturer may refer to a particular bottle as ‘small clear bottle’, but a filler may know it as ‘500 ml clear bottle’. In a database it may be recorded as ‘0.5L PET Bottle’. While these are all referring to the same thing, it could be hard for a human to know that they are the same, and pretty much impossible for a computer. 
+Identifiers are the way that humans and machines can know that a particular thing is definitely that thing. In the context of Open 3P, there are different ways of talking about the various things involved. A packaging manufacturer may refer to a particular bottle as ‘small clear bottle’, but a filler may know it as ‘500 ml clear bottle’. In a database it may be recorded as ‘0.5L PET Bottle’. While these are all referring to the same thing, it could be hard for a human to know that they are the same, and pretty much impossible for a computer. 
 
-To help get around this, we use identifiers. These are codes that we use to unambiguously reference a particular thing in our database. We will provide documentation soon to explain how to create unique identifiers for everything being described in the Open3P standard.
+To help get around this, we use identifiers. These are codes that we use to unambiguously reference a particular thing in our database. We will provide documentation soon to explain how to create unique identifiers for everything being described in the Open 3P standard.
 
 
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,9 +4,9 @@ title: Home
 
 [![Open Data Manchester](img/Open3PFullColour.jpg)](https://www.opendatamanchester.org.uk/plastics-packaging-portal/){target=_blank}
 
-## Open3P: Definition
+## Open 3P: Definition
 
-A data standard for the plastic packaging value chain.
+A data standard for the packaging value chain.
 
 ## Version
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,8 @@
 site_name: Open3P
-site_description: Open3P is an open data standard for the plastic value chain.
+site_description: Open3P is an open data standard for the packaging value chain.
 theme:
   name: material
+  custom_dir: overrides
   favicon: img/favicon-192.png
   icon:
     repo: fontawesome/brands/git-alt

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -1,0 +1,6 @@
+<!-- Announcement bar -->
+{% extends "base.html" %}
+
+{% block announce %}
+<p>The current version of Open 3P data standard for packaging is focussed on plastic. We are currently working to extend it to all packaging materials.</p>
+{% endblock %}

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -2,5 +2,5 @@
 {% extends "base.html" %}
 
 {% block announce %}
-<p>The current version of Open 3P data standard for packaging is focussed on plastic. We are currently working to extend it to all packaging materials.</p>
+<p>The current version of Open 3P data standard for packaging is focused on plastic. We are currently working to extend it to all packaging materials.</p>
 {% endblock %}


### PR DESCRIPTION
Remove mention of "plastic value chain" and changed to "packaging value chain" referencing in places about the v1.0 being focused on plastic and that we are working on extending the standard to all materials