### PR TITLE
69 move componentcontactwithproduct to complete packaging constituents relationship list

### DIFF
--- a/docs/3_Data_Specification/3_4_Complete_Packaging.md
+++ b/docs/3_Data_Specification/3_4_Complete_Packaging.md
@@ -18,7 +18,6 @@ The complete packaging schema contains information regarding the complete packag
 |completePackagingConstituentsIdentifier|`required`|List|The information regarding the consituents that are combined to create this complete packaging. The entries should be from the [Complete Packaging Constituents Relationship List](../6_Relationship_Lists/6_003_Complete_Packaging_Constituents.md) identifier.|
 |LOWcodeWOproduct|`recommended`|String|The list of waste code for **only** the complete packaging, by itself (excluding the product). LOW code is synonymous with European Waste Catalogue Code (EWC). For example: an empty bottle would have a LOWcode of `15 01 02`. Please use [Dsposal](https://dsposal.uk/browse/ewc){target=_blank} or [legislation.gov](https://www.legislation.gov.uk/uksi/2005/895/schedule/1/made){target=_blank} to find the LOWcode. **Note**: The LOWcode can based on its combination with other components and the actual product contained in the complete packaging. Be sure to only include the complete packaging LOWcode and not the complete packaging with the product. If you cannot find the code or are uncertain please enter `Uncertain`.|
 |productType|`recommended`|String|Information about the product contained in the complete packaging. The entry here should be drawn from the [product type controlled list](../5_Controlled_Lists/5_012_Product_Type.md).|
-|componentContactWithProduct|`required`|List|What components (if any) come into direct contact with the product before purchased by a consumer? If none of the components come into contact with the product use `NA`.|
 |LOWcodeWproduct|`recommended`|String|The list of waste code for **everything** in the complete packaging. LOW code is synonymous with European Waste Catalogue Code (EWC). For example: an empty bottle would have a LOWcode of `15 01 02`. Please use [Dsposal](https://dsposal.uk/browse/ewc){target=_blank} or [legislation.gov](https://www.legislation.gov.uk/uksi/2005/895/schedule/1/made){target=_blank} to find the LOWcode. **Note**: The LOWcode can based on its combination with other components and the actual product contained in the complete packaging. Be sure to include the complete packaging LOWcode with the product. If you cannot find the code or are uncertain please enter `Uncertain`.|
 |onTheGo|`required`|Boolean|Is the complete packaging often classed as packaging that will end up in street bins?|
 |householdWaste|`required`|Boolean|Is the complete packaging often classed as packaging that will end up in kerbside collections?|
@@ -61,7 +60,6 @@ COMPONENTS }o--o{ COMPLETE_PACKAGING : within
     completePackagingConstituentsIdentifier List
     LOWcodeWOproduct String
     productType String
-    componentContactWithProduct List
     LOWcodeWproduct String
     onTheGo Boolean
     householdWaste Boolean

--- a/docs/6_Relationship_Lists/6_003_Complete_Packaging_Constituents.md
+++ b/docs/6_Relationship_Lists/6_003_Complete_Packaging_Constituents.md
@@ -12,6 +12,7 @@ The complete packaging constituents relationship list identifies the components 
 |:-|:-|:-|:-|
 |completePackagingConstituentsIdentifier|`required`|String|A globally unique identifier. See [identifiers](../4_Identifiers/4_1_Identifiers.md) section for information on how to construct this identifier|
 |completePackagingCombinationIdentifier|`required`|String|The unique identifier of the components and/or complete packaging that this complete packaging is made of. There must be an equivalent record in the `Components` OR `Complete Packaging` data.|
+|contactWithProduct|`required`|Boolean|Does this constituent come into contact with the product?|
 
 ## Diagram
 
@@ -22,6 +23,7 @@ erDiagram
   COMPLETE_PACKAGING_CONSTITUENTS {
     completePackagingConstituentsIdentifier String
     completePackagingCombinationIdentifier String
+    contactWithProduct Boolean
   }
   COMPLETE_PACKAGING_CONSTITUENTS }o--o{ COMPONENTS : attributes
   COMPLETE_PACKAGING_CONSTITUENTS }o--o{ COMPLETE_PACKAGING : attributes


### PR DESCRIPTION
This was an error, the contact with product was left in the complete packaging schema but it should have been moved to the complete packaging constituents relationship list.

I am not sure if this constitutes a minor change? It is a change to the schema so it might?!