### PR TITLE
Syntax issue - needed ''' closing each example

### DIFF
--- a/docs/3_Data_Specification/3_3_Components.md
+++ b/docs/3_Data_Specification/3_3_Components.md
@@ -131,64 +131,64 @@ The specification of this csv file is as follows:
 
     ``` json linenums="1"
     --Food grade PET pot made in Ireland
-{
-    "identifier": "9F459508-E365-0B9F-E3BB-FF4A7AED481B",
-    "name": "Thermoformed rPET tray",
-    "description": "Clear PET tray for food products",
-    "externalIdentifiers": {
-        "internalId": "14",
-        "GTIN": "00123456789012"
-    },
-    "imageURLs": [
+    {
+        "identifier": "9F459508-E365-0B9F-E3BB-FF4A7AED481B",
+        "name": "Thermoformed rPET tray",
+        "description": "Clear PET tray for food products",
+        "externalIdentifiers": {
+            "internalId": "14",
+            "GTIN": "00123456789012"
+        },
+        "imageURLs": [
         "http://standard.open3p.org/2.0/img/measurements/figure1.measuring.png"
-    ],
-    "LOWcode": "150102",
-    "componentConstituents": [
-        "DCEE1F88-A83B-5BBC-D2D9-6A862B344977"
-    ],
-    "height": 50,
-    "heightDate": "01/08/2022",
-    "width": 220,
-    "widthDate": "01/08/2022",
-    "depth": 170,
-    "depthDate": "01/08/2022",
-    "volume": 1870,
-    "volumeDate": "01/08/2022",
-    "weight": 23,
-    "weightTolerance": 1.5,
-    "weightToleranceType": "grams",
-    "weightDate": "01/08/2022",
-    "shape": "c-shape-0004",
-    "function": "function-0041",
-    "flexibility": "c-flexibility-0002",
-    "branding": true,
-    "componentEndOfLifeRoutes": [
-
-    ],
-    "colour": "cmyk(0%,0%,0%,10%)",
-    "opacity": "c-opacity-0002",
-    "loaned": false,
-    "reuseSystems": [
-        "c-reuse-system-0001"
-    ],
-    "partOfMultipack": false,
-    "recycledContent": 0.3,
-    "recycledContentClaims": [
-        "23e8251a-4fe6-4b25-9966-b08acac9ba34"
-    ],
-    "recyclability": true,
-    "recyclabilityClaims": [
-        "b101889f-87e5-4c42-abb7-0df5fc3d1a26"
-    ],
-    "certification": true,
-    "certificationClaims": [
-        "eed87ac3-6e3e-45fb-af2c-dd0f64fdb597"
-    ],
-    "manufacturedCountry": 372,
-    "updateDate": "01/08/2022",
-    "releaseDate": "01/08/2022",
-    "discontinueDate": ""
-}
+        ],
+        "LOWcode": "150102",
+        "componentConstituents": [
+            "DCEE1F88-A83B-5BBC-D2D9-6A862B344977"
+        ],
+        "height": 50,
+        "heightDate": "01/08/2022",
+        "width": 220,
+        "widthDate": "01/08/2022",
+        "depth": 170,
+        "depthDate": "01/08/2022",
+        "volume": 1870,
+        "volumeDate": "01/08/2022",
+        "weight": 23,
+        "weightTolerance": 1.5,
+        "weightToleranceType": "grams",
+        "weightDate": "01/08/2022",
+        "shape": "c-shape-0004",
+        "function": "function-0041",
+        "flexibility": "c-flexibility-0002",
+        "branding": true,
+        "componentEndOfLifeRoutes": [
+            ""
+        ],
+        "colour": "cmyk(0%,0%,0%,10%)",
+        "opacity": "c-opacity-0002",
+        "loaned": false,
+        "reuseSystems": [
+            "c-reuse-system-0001"
+        ],
+        "partOfMultipack": false,
+        "recycledContent": 0.3,
+        "recycledContentClaims": [
+            "23e8251a-4fe6-4b25-9966-b08acac9ba34"
+        ],
+        "recyclability": true,
+        "recyclabilityClaims": [
+            "b101889f-87e5-4c42-abb7-0df5fc3d1a26"
+        ],
+        "certification": true,
+        "certificationClaims": [
+            "eed87ac3-6e3e-45fb-af2c-dd0f64fdb597"
+        ],
+        "manufacturedCountry": 372,
+        "updateDate": "01/08/2022",
+        "releaseDate": "01/08/2022",
+        "discontinueDate": ""
+    }
     ```
 === "CSV download"
 

--- a/docs/3_Data_Specification/3_4_Complete_Packaging.md
+++ b/docs/3_Data_Specification/3_4_Complete_Packaging.md
@@ -123,61 +123,61 @@ The specification of this csv file is as follows:
 
     ``` json linenums="1"
     {
-    "identifier": "63df4b40-ba4f-472e-a260-f8a944eb7961",
-    "name": "4 Breaded Chicken Steaks packaging",
-    "description": "PET tray, lidding film, top & base label",
-    "externalIdentifiers": {
-        "internalIdentifer": "85467889",
-        "GTIN": "00123456789012"
-        },
-    "imageURLs": [
-        "http://standard.open3p.org/2.0/img/measurements/figure1.measuring.png"
-    ],
-    "completePackagingConstituentsIdentifier": [
-        "9F459508-E365-0B9F-E3BB-FF4A7AED481B", "7197de37-8b77-4032-b0fd-84f27bae97be", "0e9a7265-6213-4a76-9a45-3acc5d83fa6f", "1c042eee-ec7a-400b-b05b-ca0d319e9067"
-    ],
-    "LOWcodeWOproduct": "15 01 06",
-    "productType": "cp-product-type-0001",
-    "componentContactWithProduct": [
-        "9F459508-E365-0B9F-E3BB-FF4A7AED481B", "7197de37-8b77-4032-b0fd-84f27bae97be"
-    ],
-    "LOWcodeWproduct": "20 01 08",
-    "onTheGo": false,
-    "householdWaste": true,
-    "depositReturnSchemes": [
-        "cp-drs-0005"
-    ],
-    "completePackagingEndOfLifeRoutes": [
-        "1229f395-3065-4236-bc1e-2aa500f58a79"
-    ],
-    "recyclability": false,
-    "recyclabilityClaims": [
-        "b101889f-87e5-4c42-abb7-0df5fc3d1a26"
-    ],
-    "height": 220,
-    "heightDate": "01/01/2023",
-    "width": 170,
-    "widthDate": "01/01/2023",
-    "depth": 60,
-    "depthDate": "01/01/2023",
-    "volume": 0.002,
-    "volumeDate": "01/01/2023",
-    "weight": 32.8,
-    "weightTolerance": 5,
-    "weightToleranceType": "percentage",
-    "weightDate": "01/01/2023",
-    "servingCapacity": 4,
-    "servingCapacityDate": "01/01/2023",
-    "partOfMultipack": false,
-    "certification": true,
-    "certificationClaims": [
-        "eed87ac3-6e3e-45fb-af2c-dd0f64fdb597"
-    ],
-    "manufacturedCountry": 826,
-    "updateDate": "01/01/2023",
-    "releaseDate": "01/01/2023",
-    "discontinueDate": ""
-}
+        "identifier": "63df4b40-ba4f-472e-a260-f8a944eb7961",
+        "name": "4 Breaded Chicken Steaks packaging",
+        "description": "PET tray, lidding film, top & base label",
+        "externalIdentifiers": {
+            "internalIdentifer": "85467889",
+            "GTIN": "00123456789012"
+            },
+        "imageURLs": [
+            "http://standard.open3p.org/2.0/img/measurements/figure1.measuring.png"
+        ],
+        "completePackagingConstituentsIdentifier": [
+            "9F459508-E365-0B9F-E3BB-FF4A7AED481B", "7197de37-8b77-4032-b0fd-84f27bae97be", "0e9a7265-6213-4a76-9a45-3acc5d83fa6f", "1c042eee-ec7a-400b-b05b-ca0d319e9067"
+        ],
+        "LOWcodeWOproduct": "15 01 06",
+        "productType": "cp-product-type-0001",
+        "componentContactWithProduct": [
+            "9F459508-E365-0B9F-E3BB-FF4A7AED481B", "7197de37-8b77-4032-b0fd-84f27bae97be"
+        ],
+        "LOWcodeWproduct": "20 01 08",
+        "onTheGo": false,
+        "householdWaste": true,
+        "depositReturnSchemes": [
+            "cp-drs-0005"
+        ],
+        "completePackagingEndOfLifeRoutes": [
+            "1229f395-3065-4236-bc1e-2aa500f58a79"
+        ],
+        "recyclability": false,
+        "recyclabilityClaims": [
+            "b101889f-87e5-4c42-abb7-0df5fc3d1a26"
+        ],
+        "height": 220,
+        "heightDate": "01/01/2023",
+        "width": 170,
+        "widthDate": "01/01/2023",
+        "depth": 60,
+        "depthDate": "01/01/2023",
+        "volume": 0.002,
+        "volumeDate": "01/01/2023",
+        "weight": 32.8,
+        "weightTolerance": 5,
+        "weightToleranceType": "percentage",
+        "weightDate": "01/01/2023",
+        "servingCapacity": 4,
+        "servingCapacityDate": "01/01/2023",
+        "partOfMultipack": false,
+        "certification": true,
+        "certificationClaims": [
+            "eed87ac3-6e3e-45fb-af2c-dd0f64fdb597"
+        ],
+        "manufacturedCountry": 826,
+        "updateDate": "01/01/2023",
+        "releaseDate": "01/01/2023",
+        "discontinueDate": ""
+    }
     ```
 === "CSV download"
 

--- a/docs/6_Relationship_Lists/6_005_Certification_Claims.md
+++ b/docs/6_Relationship_Lists/6_005_Certification_Claims.md
@@ -43,9 +43,10 @@ erDiagram
 === "JSON"
 
     ``` json linenums="1"
-    --A certificate provided by the FSA
-{
-    "certificationIdentifier": "eed87ac3-6e3e-45fb-af2c-dd0f64fdb597",
-    "certificationSource": "certification-source-0002",
-    "certificationIssueDate": "01/08/2022"
-}
+    --A certificate provided by the FSA.
+    {
+      "certificationIdentifier": "eed87ac3-6e3e-45fb-af2c-dd0f64fdb597",
+      "certificationSource": "certification-source-0002",
+      "certificationIssueDate": "01/08/2022"
+    }
+    ```

--- a/docs/6_Relationship_Lists/6_006_Recyclability_Claims.md
+++ b/docs/6_Relationship_Lists/6_006_Recyclability_Claims.md
@@ -40,9 +40,10 @@ erDiagram
 === "JSON"
 
     ``` json linenums="1"
-    --Claim provided by OPRL
-{
-    "recyclabilityIdentifier": "b101889f-87e5-4c42-abb7-0df5fc3d1a26",
-    "recyclabilitySource": "recyclability-source-0001",
-    "recyclabilityIssueDate": "01/08/2022"
-}
+    --Claim provided by OPRL.
+    {
+      "recyclabilityIdentifier": "b101889f-87e5-4c42-abb7-0df5fc3d1a26",
+      "recyclabilitySource": "recyclability-source-0001",
+      "recyclabilityIssueDate": "01/08/2022"
+    }
+    ```

--- a/docs/6_Relationship_Lists/6_008_Complete_Packaging_End_of_Life_Routes.md
+++ b/docs/6_Relationship_Lists/6_008_Complete_Packaging_End_of_Life_Routes.md
@@ -39,12 +39,13 @@ erDiagram
 === "JSON"
 
     ``` json linenums="1"
-    --A complete packaging end of life route for recycling with food residue and a paper label being a disruptor
-{
-    "completePackagingEndOfLifeRouteIdentifier": "1229f395-3065-4236-bc1e-2aa500f58a79",
-    "completePackagingEndOfLifeRoute": "end-of-life-route-0001",
-    "orderOfPrecedence": 1,
-    "completePackagingDistruptors": [
-        "cp-disruptors-0029", "cp-disruptors-0022"
-    ]
-}
+    --A complete packaging end of life route for recycling with food residue and a paper label being a disruptor.
+    {
+      "completePackagingEndOfLifeRouteIdentifier": "1229f395-3065-4236-bc1e-2aa500f58a79",
+      "completePackagingEndOfLifeRoute": "end-of-life-route-0001",
+      "orderOfPrecedence": 1,
+      "completePackagingDistruptors": [
+          "cp-disruptors-0029", "cp-disruptors-0022"
+      ]
+    }
+    ```

--- a/docs/6_Relationship_Lists/6_009_Recycled_Content_Claims.md
+++ b/docs/6_Relationship_Lists/6_009_Recycled_Content_Claims.md
@@ -38,10 +38,11 @@ erDiagram
 === "JSON"
 
     ``` json linenums="1"
-    --A certificate providing information about a recycled content claim
-{
-    "recycledContentIdentifier": "23e8251a-4fe6-4b25-9966-b08acac9ba34",
-    "recycledContentEvidenceType": "c-recycled-evidence-0001",
-    "recycledContentEvidenceReference": "ABC-123-Example",
-    "recycledContentIssueDate": "01/08/2022"
-}
+    --A certificate providing information about a recycled content claim.
+    {
+      "recycledContentIdentifier": "23e8251a-4fe6-4b25-9966-b08acac9ba34",
+      "recycledContentEvidenceType": "c-recycled-evidence-0001",
+      "recycledContentEvidenceReference": "ABC-123-Example",
+      "recycledContentIssueDate": "01/08/2022"
+    }
+    ```


### PR DESCRIPTION
Two issues.
1) In components and complete packaging the was a blank list which snapped the view.  This has been fixed
2) In the relationship lists there needed to be three apostrophes as closing syntax. This has been fixed.